### PR TITLE
Fix SSRF in movie poster download

### DIFF
--- a/internal/application/poster_service.go
+++ b/internal/application/poster_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,11 @@ import (
 const (
 	tmdbImageBaseW500 = "https://image.tmdb.org/t/p/w500"
 	tmdbImageBaseW185 = "https://image.tmdb.org/t/p/w185"
+
+	// tmdbImageHost is the only host from which posters may be downloaded.
+	// Restricting downloads to this host prevents SSRF via a caller-supplied
+	// posterURL (e.g. pointing at internal services or the cloud metadata server).
+	tmdbImageHost = "image.tmdb.org"
 )
 
 // MoviePosterResult represents a movie poster search result returned to callers
@@ -56,6 +62,11 @@ func (s *PosterService) FetchMoviePoster(videoPath, movieTitle, posterURL string
 	var actualPosterURL string
 
 	if posterURL != "" {
+		// posterURL is caller-supplied; restrict it to the TMDb image host to
+		// prevent the server being coerced into fetching arbitrary URLs (SSRF).
+		if err := validatePosterURL(posterURL); err != nil {
+			return err
+		}
 		send("Using selected poster", 30)
 		actualPosterURL = posterURL
 	} else {
@@ -133,6 +144,25 @@ func (s *PosterService) SearchMoviePoster(movieTitle string) ([]MoviePosterResul
 		}
 	}
 	return posters, nil
+}
+
+// validatePosterURL ensures a caller-supplied poster URL points at the trusted
+// TMDb image host over HTTPS. This blocks SSRF attempts that would otherwise let
+// a request coerce the server into fetching internal or arbitrary URLs.
+func validatePosterURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid poster URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("poster URL must use https")
+	}
+	// Hostname() strips any port and userinfo, so this cannot be bypassed with
+	// constructs like "image.tmdb.org@evil.com" or "image.tmdb.org:1234".
+	if !strings.EqualFold(u.Hostname(), tmdbImageHost) {
+		return fmt.Errorf("poster URL host is not allowed")
+	}
+	return nil
 }
 
 // cleanMovieTitle removes common metadata suffixes from a movie title so that

--- a/internal/application/poster_service_test.go
+++ b/internal/application/poster_service_test.go
@@ -1,0 +1,30 @@
+package application
+
+import "testing"
+
+func TestValidatePosterURL(t *testing.T) {
+	allowed := []string{
+		"https://image.tmdb.org/t/p/w500/abc.jpg",
+		"https://IMAGE.TMDB.ORG/t/p/w185/def.jpg",
+	}
+	for _, u := range allowed {
+		if err := validatePosterURL(u); err != nil {
+			t.Errorf("expected %q to be allowed, got error: %v", u, err)
+		}
+	}
+
+	blocked := []string{
+		"http://image.tmdb.org/t/p/w500/abc.jpg",      // not https
+		"https://169.254.169.254/computeMetadata/v1/", // cloud metadata
+		"https://evil.com/x.jpg",                      // arbitrary host
+		"https://image.tmdb.org.evil.com/x.jpg",       // suffix trick
+		"https://image.tmdb.org@evil.com/x.jpg",       // userinfo trick
+		"file:///etc/passwd",                          // non-http scheme
+		"",                                            // empty
+	}
+	for _, u := range blocked {
+		if err := validatePosterURL(u); err == nil {
+			t.Errorf("expected %q to be blocked, but it was allowed", u)
+		}
+	}
+}

--- a/internal/infrastructure/tmdb/client.go
+++ b/internal/infrastructure/tmdb/client.go
@@ -8,13 +8,29 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"video-gallery/internal/domain/gallery"
 )
 
 const (
 	tmdbSearchURL = "https://api.themoviedb.org/3/search/movie"
+
+	// tmdbImageHost is the only host images may be downloaded from.
+	tmdbImageHost = "image.tmdb.org"
+
+	// maxImageBytes caps the size of a downloaded poster to avoid unbounded
+	// memory/disk use from a malicious or oversized response.
+	maxImageBytes = 25 * 1024 * 1024 // 25 MiB
+
+	// httpTimeout bounds outbound HTTP requests so a slow or hostile endpoint
+	// cannot hang a request indefinitely.
+	httpTimeout = 30 * time.Second
 )
+
+// httpClient is a shared client with a bounded timeout for all outbound requests.
+var httpClient = &http.Client{Timeout: httpTimeout}
 
 // tmdbSearchResult is the raw response shape from the TMDb search API
 type tmdbSearchResult struct {
@@ -46,7 +62,7 @@ func (c *Client) SearchMovies(_ context.Context, title string) ([]gallery.MovieR
 	}
 
 	searchURL := fmt.Sprintf("%s?api_key=%s&query=%s", tmdbSearchURL, apiKey, url.QueryEscape(title))
-	resp, err := http.Get(searchURL) // #nosec G107 -- URL is constructed from trusted constant + encoded user input
+	resp, err := httpClient.Get(searchURL) // #nosec G107 -- URL is constructed from a trusted constant + encoded user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to search TMDb: %v", err)
 	}
@@ -74,9 +90,15 @@ func (c *Client) SearchMovies(_ context.Context, title string) ([]gallery.MovieR
 	return results, nil
 }
 
-// DownloadImage downloads an image from imageURL and saves it to destPath
+// DownloadImage downloads an image from imageURL and saves it to destPath.
+// imageURL must be an HTTPS URL on the TMDb image host; this guards against
+// SSRF in case an unvalidated URL ever reaches this method.
 func (c *Client) DownloadImage(_ context.Context, imageURL, destPath string) error {
-	resp, err := http.Get(imageURL) // #nosec G107 -- URL is a TMDb image URL provided by the application
+	if err := validateImageURL(imageURL); err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Get(imageURL) // #nosec G107 -- validateImageURL restricts the host to the TMDb image CDN
 	if err != nil {
 		return fmt.Errorf("failed to download image: %v", err)
 	}
@@ -92,8 +114,29 @@ func (c *Client) DownloadImage(_ context.Context, imageURL, destPath string) err
 	}
 	defer f.Close()
 
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	// Cap the number of bytes read so an oversized response cannot exhaust disk/memory.
+	limited := io.LimitReader(resp.Body, maxImageBytes+1)
+	written, err := io.Copy(f, limited)
+	if err != nil {
 		return fmt.Errorf("failed to write image data: %v", err)
+	}
+	if written > maxImageBytes {
+		return fmt.Errorf("image exceeds maximum allowed size of %d bytes", maxImageBytes)
+	}
+	return nil
+}
+
+// validateImageURL ensures imageURL uses HTTPS and targets the TMDb image host.
+func validateImageURL(imageURL string) error {
+	u, err := url.Parse(imageURL)
+	if err != nil {
+		return fmt.Errorf("invalid image URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("image URL must use https")
+	}
+	if !strings.EqualFold(u.Hostname(), tmdbImageHost) {
+		return fmt.Errorf("image URL host is not allowed")
 	}
 	return nil
 }


### PR DESCRIPTION
The poster fetch endpoint accepted a caller-supplied posterUrl that flowed
unvalidated into a server-side http.Get, allowing an authenticated request
to coerce the server into fetching arbitrary URLs (e.g. the cloud metadata
server or internal services) and storing the response in the bucket.

- Validate caller-supplied poster URLs against the TMDb image host over
  HTTPS at the service boundary, rejecting host/userinfo/port bypass tricks.
- Re-validate the host in the downloader as defense-in-depth and correct the
  misleading nosec rationale.
- Bound outbound HTTP requests with a timeout and cap downloaded image size
  to prevent hangs and resource exhaustion.
- Add tests for the URL allowlist.

https://claude.ai/code/session_01Hz4t8AbV78tMomxadwSy6f