### PR TITLE
Security hardening: XSS prevention, input validation, and headers

### DIFF
--- a/assets/templates/admin.pug
+++ b/assets/templates/admin.pug
@@ -578,7 +578,7 @@ html
             |                 card.className = 'card poster-card';
             |                 card.dataset.videoPath = videoPath;
             |                 card.dataset.movieTitle = movie.title;
-            |                 card.dataset.posterUrl = movie.posterUrl;
+            |                 card.dataset.movieId = movie.id;
             |                 const cardImage = document.createElement('div');
             |                 cardImage.className = 'card-image';
             |                 const figure = document.createElement('figure');
@@ -619,8 +619,8 @@ html
             |                 card.addEventListener('click', function() {
             |                     const videoPath = this.dataset.videoPath;
             |                     const movieTitle = this.dataset.movieTitle;
-            |                     const posterUrl = this.dataset.posterUrl;
-            |                     confirmPosterSelection(row, videoPath, movieTitle, posterUrl);
+            |                     const movieId = this.dataset.movieId;
+            |                     confirmPosterSelection(row, videoPath, movieTitle, movieId);
             |                 });
             |             });
             |             
@@ -639,14 +639,14 @@ html
             |         });
             | }
             | 
-            | function confirmPosterSelection(row, videoPath, movieTitle, posterUrl) {
+            | function confirmPosterSelection(row, videoPath, movieTitle, movieId) {
             |     const statusDiv = row.querySelector('.status-msg');
             |     
             |     statusDiv.classList.remove('is-danger');
             |     statusDiv.classList.add('is-info');
             |     statusDiv.innerHTML = '<progress class="progress is-small is-info" value="0" max="100">0%</progress><span>Fetching poster...</span>';
             |     
-            |     const eventSource = new EventSource('/' + secretKey + '/admin/api/fetch-movie-poster?videoPath=' + encodeURIComponent(videoPath) + '&movieTitle=' + encodeURIComponent(movieTitle) + '&posterUrl=' + encodeURIComponent(posterUrl));
+            |     const eventSource = new EventSource('/' + secretKey + '/admin/api/fetch-movie-poster?videoPath=' + encodeURIComponent(videoPath) + '&movieTitle=' + encodeURIComponent(movieTitle) + '&movieId=' + encodeURIComponent(movieId));
             |     
             |     eventSource.onmessage = function(event) {
             |         const data = JSON.parse(event.data);

--- a/assets/templates/admin.pug
+++ b/assets/templates/admin.pug
@@ -128,7 +128,22 @@ html
 
         script
             | const secretKey = '#{SecretKey}';
-            | 
+            |
+            | /* Render a progress bar + label without innerHTML so that
+            |    externally sourced text (API errors, movie data) cannot inject markup. */
+            | function setStatusProgress(statusDiv, progress, step) {
+            |     statusDiv.textContent = '';
+            |     const bar = document.createElement('progress');
+            |     bar.className = 'progress is-small is-info';
+            |     bar.value = progress;
+            |     bar.max = 100;
+            |     bar.textContent = progress + '%';
+            |     const label = document.createElement('span');
+            |     label.textContent = step + '...';
+            |     statusDiv.appendChild(bar);
+            |     statusDiv.appendChild(label);
+            | }
+            |
             | function saveFilterState() {
             |     const params = new URLSearchParams();
             |     const category = document.getElementById('filterCategory').value;
@@ -461,7 +476,7 @@ html
             |             eventSource.close();
             |             statusDiv.classList.remove('is-info', 'is-success');
             |             statusDiv.classList.add('is-danger');
-            |             statusDiv.innerHTML = 'Error: ' + data.error;
+            |             statusDiv.textContent = 'Error: ' + data.error;
             |             if (callback) callback();
             |             return;
             |         }
@@ -479,14 +494,14 @@ html
             |             return;
             |         }
             |         
-            |         statusDiv.innerHTML = '<progress class="progress is-small is-info" value="' + data.progress + '" max="100">' + data.progress + '%</progress><span>' + data.step + '...</span>';
+            |         setStatusProgress(statusDiv, data.progress, data.step);
             |     };
             |     
             |     eventSource.onerror = function(error) {
             |         eventSource.close();
             |         statusDiv.classList.remove('is-info', 'is-success');
             |         statusDiv.classList.add('is-danger');
-            |         statusDiv.innerHTML = 'Error: Connection failed';
+            |         statusDiv.textContent = 'Error: Connection failed';
             |         if (callback) callback();
             |     };
             | }
@@ -534,30 +549,70 @@ html
             |             if (!results || results.length === 0) {
             |                 statusDiv.classList.remove('is-info', 'is-success');
             |                 statusDiv.classList.add('is-danger');
-            |                 statusDiv.innerHTML = 'No movies found for: ' + movieTitle;
+            |                 statusDiv.textContent = 'No movies found for: ' + movieTitle;
             |                 return;
             |             }
             |             
-            |             /* Show poster selection UI */
+            |             /* Show poster selection UI. Built with DOM APIs (not innerHTML)
+            |                because movie titles/URLs come from the external TMDb API. */
             |             statusDiv.classList.remove('is-danger');
             |             statusDiv.classList.add('is-info');
-            |             
-            |             let html = '<div class="poster-selection"><p class="mb-3"><strong>Select the correct movie:</strong></p><div class="columns is-multiline is-mobile is-variable is-2">';
-            |             
-            |             results.slice(0, 5).forEach(function(movie, index) {
-            |                 html += '<div class="column is-one-quarter-desktop is-one-third-tablet is-half-mobile">';
-            |                 html += '<div class="card poster-card" data-video-path="' + videoPath + '" data-movie-title="' + movie.title.replace(/"/g, '&quot;') + '" data-poster-url="' + movie.posterUrl + '">';
-            |                 html += '<div class="card-image"><figure class="image is-2by3">';
-            |                 html += '<img src="' + movie.thumbnailUrl + '" alt="' + movie.title + '">';
-            |                 html += '</figure></div>';
-            |                 html += '<div class="card-content p-2"><p class="is-size-7 has-text-centered has-text-weight-semibold">' + movie.title;
-            |                 if (movie.year) html += '<br><span class="has-text-grey">(' + movie.year + ')</span>';
-            |                 html += '</p></div></div></div>';
+            |             statusDiv.textContent = '';
+            |
+            |             const selection = document.createElement('div');
+            |             selection.className = 'poster-selection';
+            |             const heading = document.createElement('p');
+            |             heading.className = 'mb-3';
+            |             const headingText = document.createElement('strong');
+            |             headingText.textContent = 'Select the correct movie:';
+            |             heading.appendChild(headingText);
+            |             selection.appendChild(heading);
+            |
+            |             const columns = document.createElement('div');
+            |             columns.className = 'columns is-multiline is-mobile is-variable is-2';
+            |
+            |             results.slice(0, 5).forEach(function(movie) {
+            |                 const column = document.createElement('div');
+            |                 column.className = 'column is-one-quarter-desktop is-one-third-tablet is-half-mobile';
+            |                 const card = document.createElement('div');
+            |                 card.className = 'card poster-card';
+            |                 card.dataset.videoPath = videoPath;
+            |                 card.dataset.movieTitle = movie.title;
+            |                 card.dataset.posterUrl = movie.posterUrl;
+            |                 const cardImage = document.createElement('div');
+            |                 cardImage.className = 'card-image';
+            |                 const figure = document.createElement('figure');
+            |                 figure.className = 'image is-2by3';
+            |                 const img = document.createElement('img');
+            |                 img.src = movie.thumbnailUrl;
+            |                 img.alt = movie.title;
+            |                 figure.appendChild(img);
+            |                 cardImage.appendChild(figure);
+            |                 card.appendChild(cardImage);
+            |                 const content = document.createElement('div');
+            |                 content.className = 'card-content p-2';
+            |                 const text = document.createElement('p');
+            |                 text.className = 'is-size-7 has-text-centered has-text-weight-semibold';
+            |                 text.textContent = movie.title;
+            |                 if (movie.year) {
+            |                     text.appendChild(document.createElement('br'));
+            |                     const year = document.createElement('span');
+            |                     year.className = 'has-text-grey';
+            |                     year.textContent = '(' + movie.year + ')';
+            |                     text.appendChild(year);
+            |                 }
+            |                 content.appendChild(text);
+            |                 card.appendChild(content);
+            |                 column.appendChild(card);
+            |                 columns.appendChild(column);
             |             });
-            |             
-            |             html += '</div><button class="button is-small is-light mt-2 cancel-poster-btn">Cancel</button></div>';
-            |             
-            |             statusDiv.innerHTML = html;
+            |
+            |             selection.appendChild(columns);
+            |             const cancelBtn = document.createElement('button');
+            |             cancelBtn.className = 'button is-small is-light mt-2 cancel-poster-btn';
+            |             cancelBtn.textContent = 'Cancel';
+            |             selection.appendChild(cancelBtn);
+            |             statusDiv.appendChild(selection);
             |             
             |             /* Add click handlers to poster cards */
             |             statusDiv.querySelectorAll('.poster-card').forEach(function(card) {
@@ -580,7 +635,7 @@ html
             |         .catch(function(error) {
             |             statusDiv.classList.remove('is-info', 'is-success');
             |             statusDiv.classList.add('is-danger');
-            |             statusDiv.innerHTML = 'Error: ' + error.message;
+            |             statusDiv.textContent = 'Error: ' + error.message;
             |         });
             | }
             | 
@@ -600,7 +655,7 @@ html
             |             eventSource.close();
             |             statusDiv.classList.remove('is-info', 'is-success');
             |             statusDiv.classList.add('is-danger');
-            |             statusDiv.innerHTML = 'Error: ' + data.error;
+            |             statusDiv.textContent = 'Error: ' + data.error;
             |             return;
             |         }
             |         
@@ -613,14 +668,14 @@ html
             |             return;
             |         }
             |         
-            |         statusDiv.innerHTML = '<progress class="progress is-small is-info" value="' + data.progress + '" max="100">' + data.progress + '%</progress><span>' + data.step + '...</span>';
+            |         setStatusProgress(statusDiv, data.progress, data.step);
             |     };
             |     
             |     eventSource.onerror = function(error) {
             |         eventSource.close();
             |         statusDiv.classList.remove('is-info', 'is-success');
             |         statusDiv.classList.add('is-danger');
-            |         statusDiv.innerHTML = 'Error: Connection failed';
+            |         statusDiv.textContent = 'Error: Connection failed';
             |     };
             | }
             | 

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/spf13/cobra"
@@ -60,21 +61,48 @@ func serveWebsite(cfg *config.Config) error {
 	adminHandlers := handlers.NewAdminHandlers(gallerySvc, thumbnailSvc, posterSvc, cfg.SecretKey)
 
 	// --- Routes ---
+	mux := http.NewServeMux()
 	fileServer := http.FileServer(http.Dir("./public"))
-	http.Handle("/", fileServer)
-	http.HandleFunc("/gallery/", galleryHandlers.PageHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/index", cfg.SecretKey), galleryHandlers.IndexHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/feed", cfg.SecretKey), galleryHandlers.FeedHandler)
+	mux.Handle("/", fileServer)
+	mux.HandleFunc("/gallery/", galleryHandlers.PageHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/index", cfg.SecretKey), galleryHandlers.IndexHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/feed", cfg.SecretKey), galleryHandlers.FeedHandler)
 
 	// Admin routes — all protected by the secret key
-	http.HandleFunc(fmt.Sprintf("/%s/admin", cfg.SecretKey), adminHandlers.AdminHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/generate-thumbnail", cfg.SecretKey), adminHandlers.GenerateThumbnailHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/clear-thumbnail", cfg.SecretKey), adminHandlers.ClearThumbnailHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/bulk-generate-thumbnails", cfg.SecretKey), adminHandlers.BulkGenerateThumbnailsHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/bulk-clear-thumbnails", cfg.SecretKey), adminHandlers.BulkClearThumbnailsHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/fetch-movie-poster", cfg.SecretKey), adminHandlers.FetchMoviePosterHandler)
-	http.HandleFunc(fmt.Sprintf("/%s/admin/api/search-movie-poster", cfg.SecretKey), adminHandlers.SearchMoviePosterHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin", cfg.SecretKey), adminHandlers.AdminHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/generate-thumbnail", cfg.SecretKey), adminHandlers.GenerateThumbnailHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/clear-thumbnail", cfg.SecretKey), adminHandlers.ClearThumbnailHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/bulk-generate-thumbnails", cfg.SecretKey), adminHandlers.BulkGenerateThumbnailsHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/bulk-clear-thumbnails", cfg.SecretKey), adminHandlers.BulkClearThumbnailsHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/fetch-movie-poster", cfg.SecretKey), adminHandlers.FetchMoviePosterHandler)
+	mux.HandleFunc(fmt.Sprintf("/%s/admin/api/search-movie-poster", cfg.SecretKey), adminHandlers.SearchMoviePosterHandler)
+
+	// No WriteTimeout: the admin SSE endpoints hold long-lived streaming responses.
+	server := &http.Server{
+		Addr:              cfg.ServerAddress(),
+		Handler:           securityHeaders(mux),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 
 	cfg.PrintServerStartMessage()
-	return http.ListenAndServe(cfg.ServerAddress(), nil)
+	return server.ListenAndServe()
+}
+
+// securityHeaders adds standard browser security headers to every response.
+// Referrer-Policy is set to no-referrer because the secret key is part of the
+// URL and must never leak through the Referer header. script-src/style-src
+// allow 'unsafe-inline' because the pug templates use inline scripts and styles.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'self'; img-src 'self' https: data:; media-src 'self' https:; "+
+				"script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "+
+				"connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'")
+		next.ServeHTTP(w, r)
+	})
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,20 +2,29 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Only the latest released version of video-gallery is supported with security
+updates. Please upgrade to the most recent release before reporting an issue.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/eveenendaal/video-gallery/security/advisories/new)
+rather than opening a public issue.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Include as much detail as you can: affected version, reproduction steps, and
+potential impact. You can expect an initial response within a week. Once a fix
+is available, the vulnerability will be disclosed in the release notes.
+
+## Deployment Security Notes
+
+Access to the gallery and admin pages is controlled entirely by the
+`SECRET_KEY` URL prefix. When deploying:
+
+- Use a long, random `SECRET_KEY` (32+ characters). The bundled Terraform
+  module generates one automatically.
+- Always serve the application behind HTTPS — the secret key is part of every
+  URL.
+- Treat gallery URLs as capability links: anyone with a link can view that
+  gallery and its videos until the signed URLs expire (24 hours).
+- The GCS bucket should remain private; the application only exposes content
+  through time-limited signed URLs.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -25,6 +25,8 @@ Access to the gallery and admin pages is controlled entirely by the
 - Always serve the application behind HTTPS — the secret key is part of every
   URL.
 - Treat gallery URLs as capability links: anyone with a link can view that
-  gallery and its videos until the signed URLs expire (24 hours).
+  gallery and its videos until the signed URLs expire (24 hours). Gallery
+  stubs are intentionally short (4 characters) to keep links shareable, so
+  they can be discovered by enumerating the /gallery/ namespace.
 - The GCS bucket should remain private; the application only exposes content
   through time-limited signed URLs.

--- a/internal/application/gallery_service.go
+++ b/internal/application/gallery_service.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -82,10 +83,12 @@ func (s *GalleryService) GetGalleries() []gallery.Gallery {
 		if g, exists := galleryMap[galleryName]; exists {
 			g.Videos = append(g.Videos, video)
 		} else {
-			// Generate hash for gallery URL (non-security use case — URL identifier only)
-			hash := sha256.New()
-			hash.Write([]byte(galleryName + s.secretKey))
-			hashStr := base64.URLEncoding.EncodeToString(hash.Sum(nil))[0:4]
+			// Gallery pages are served without the secret key, so the stub acts as
+			// an unguessable capability URL. Use an HMAC keyed with the secret and
+			// keep 16 url-safe base64 chars (~96 bits) to resist enumeration.
+			mac := hmac.New(sha256.New, []byte(s.secretKey))
+			mac.Write([]byte(galleryName))
+			hashStr := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))[0:16]
 
 			galleryMap[galleryName] = &gallery.Gallery{
 				Name:     galleryName,

--- a/internal/application/gallery_service.go
+++ b/internal/application/gallery_service.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"context"
-	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -83,12 +82,12 @@ func (s *GalleryService) GetGalleries() []gallery.Gallery {
 		if g, exists := galleryMap[galleryName]; exists {
 			g.Videos = append(g.Videos, video)
 		} else {
-			// Gallery pages are served without the secret key, so the stub acts as
-			// an unguessable capability URL. Use an HMAC keyed with the secret and
-			// keep 16 url-safe base64 chars (~96 bits) to resist enumeration.
-			mac := hmac.New(sha256.New, []byte(s.secretKey))
-			mac.Write([]byte(galleryName))
-			hashStr := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))[0:16]
+			// Gallery URL stub. Kept intentionally short (4 chars) so gallery
+			// links stay easy to share, at the cost of being guessable by
+			// enumeration of the /gallery/ namespace.
+			hash := sha256.New()
+			hash.Write([]byte(galleryName + s.secretKey))
+			hashStr := base64.URLEncoding.EncodeToString(hash.Sum(nil))[0:4]
 
 			galleryMap[galleryName] = &gallery.Gallery{
 				Name:     galleryName,

--- a/internal/application/poster_service.go
+++ b/internal/application/poster_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,15 +14,11 @@ import (
 const (
 	tmdbImageBaseW500 = "https://image.tmdb.org/t/p/w500"
 	tmdbImageBaseW185 = "https://image.tmdb.org/t/p/w185"
-
-	// tmdbImageHost is the only host from which posters may be downloaded.
-	// Restricting downloads to this host prevents SSRF via a caller-supplied
-	// posterURL (e.g. pointing at internal services or the cloud metadata server).
-	tmdbImageHost = "image.tmdb.org"
 )
 
 // MoviePosterResult represents a movie poster search result returned to callers
 type MoviePosterResult struct {
+	ID           int    `json:"id"`
 	Title        string `json:"title"`
 	Year         string `json:"year"`
 	PosterURL    string `json:"posterUrl"`
@@ -51,24 +46,27 @@ func NewPosterService(
 }
 
 // FetchMoviePoster downloads a movie poster and stores it as the video's thumbnail.
-// If posterURL is non-empty it is used directly; otherwise a TMDb search is performed.
-func (s *PosterService) FetchMoviePoster(videoPath, movieTitle, posterURL string, progressCb ProgressCallback) error {
+// If movieID is positive the poster is looked up by TMDb ID; otherwise a TMDb
+// title search is performed. The poster URL is always constructed server-side
+// from TMDb API responses, so callers can never make the server fetch an
+// arbitrary URL (SSRF).
+func (s *PosterService) FetchMoviePoster(videoPath, movieTitle string, movieID int, progressCb ProgressCallback) error {
 	send := func(step string, progress int) {
 		if progressCb != nil {
 			progressCb(step, progress)
 		}
 	}
 
-	var actualPosterURL string
+	var movie gallery.MovieResult
 
-	if posterURL != "" {
-		// posterURL is caller-supplied; restrict it to the TMDb image host to
-		// prevent the server being coerced into fetching arbitrary URLs (SSRF).
-		if err := validatePosterURL(posterURL); err != nil {
-			return err
+	if movieID > 0 {
+		send("Fetching selected movie", 15)
+
+		var err error
+		movie, err = s.client.GetMovie(context.Background(), movieID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch movie: %v", err)
 		}
-		send("Using selected poster", 30)
-		actualPosterURL = posterURL
 	} else {
 		send("Searching for movie", 15)
 
@@ -81,13 +79,14 @@ func (s *PosterService) FetchMoviePoster(videoPath, movieTitle, posterURL string
 			return fmt.Errorf("no movie found for title: %s", movieTitle)
 		}
 
-		movie := findBestMatch(results, cleanTitle)
-		if movie.PosterPath == nil || *movie.PosterPath == "" {
-			return fmt.Errorf("no poster available for: %s", movieTitle)
-		}
-
-		actualPosterURL = tmdbImageBaseW500 + *movie.PosterPath
+		movie = findBestMatch(results, cleanTitle)
 	}
+
+	if movie.PosterPath == nil || *movie.PosterPath == "" {
+		return fmt.Errorf("no poster available for: %s", movieTitle)
+	}
+
+	actualPosterURL := tmdbImageBaseW500 + *movie.PosterPath
 
 	send("Downloading poster", 40)
 
@@ -136,6 +135,7 @@ func (s *PosterService) SearchMoviePoster(movieTitle string) ([]MoviePosterResul
 	for _, movie := range results {
 		if movie.PosterPath != nil && *movie.PosterPath != "" {
 			posters = append(posters, MoviePosterResult{
+				ID:           movie.ID,
 				Title:        movie.Title,
 				Year:         extractYear(movie.ReleaseDate),
 				PosterURL:    tmdbImageBaseW500 + *movie.PosterPath,
@@ -144,25 +144,6 @@ func (s *PosterService) SearchMoviePoster(movieTitle string) ([]MoviePosterResul
 		}
 	}
 	return posters, nil
-}
-
-// validatePosterURL ensures a caller-supplied poster URL points at the trusted
-// TMDb image host over HTTPS. This blocks SSRF attempts that would otherwise let
-// a request coerce the server into fetching internal or arbitrary URLs.
-func validatePosterURL(rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("invalid poster URL")
-	}
-	if u.Scheme != "https" {
-		return fmt.Errorf("poster URL must use https")
-	}
-	// Hostname() strips any port and userinfo, so this cannot be bypassed with
-	// constructs like "image.tmdb.org@evil.com" or "image.tmdb.org:1234".
-	if !strings.EqualFold(u.Hostname(), tmdbImageHost) {
-		return fmt.Errorf("poster URL host is not allowed")
-	}
-	return nil
 }
 
 // cleanMovieTitle removes common metadata suffixes from a movie title so that

--- a/internal/domain/gallery/repository.go
+++ b/internal/domain/gallery/repository.go
@@ -31,5 +31,6 @@ type MovieResult struct {
 // MoviePosterClient defines the contract for movie poster lookup and download operations
 type MoviePosterClient interface {
 	SearchMovies(ctx context.Context, title string) ([]MovieResult, error)
+	GetMovie(ctx context.Context, id int) (MovieResult, error)
 	DownloadImage(ctx context.Context, imageURL, destPath string) error
 }

--- a/internal/infrastructure/tmdb/client.go
+++ b/internal/infrastructure/tmdb/client.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	tmdbSearchURL = "https://api.themoviedb.org/3/search/movie"
+	tmdbMovieURL  = "https://api.themoviedb.org/3/movie"
 
 	// tmdbImageHost is the only host images may be downloaded from.
 	tmdbImageHost = "image.tmdb.org"
@@ -88,6 +89,44 @@ func (c *Client) SearchMovies(_ context.Context, title string) ([]gallery.MovieR
 		})
 	}
 	return results, nil
+}
+
+// GetMovie fetches a single movie by its TMDb ID. Looking movies up by numeric
+// ID (rather than accepting a caller-supplied URL) ensures poster downloads
+// only ever use URLs constructed from TMDb's own API responses.
+func (c *Client) GetMovie(_ context.Context, id int) (gallery.MovieResult, error) {
+	apiKey := c.resolveAPIKey()
+	if apiKey == "" {
+		return gallery.MovieResult{}, fmt.Errorf("TMDB_API_KEY is not set")
+	}
+
+	movieURL := fmt.Sprintf("%s/%d?api_key=%s", tmdbMovieURL, id, apiKey)
+	resp, err := httpClient.Get(movieURL) // #nosec G107 -- URL is a trusted constant plus an integer ID
+	if err != nil {
+		return gallery.MovieResult{}, fmt.Errorf("failed to fetch movie from TMDb: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return gallery.MovieResult{}, fmt.Errorf("TMDb API error (status %d)", resp.StatusCode)
+	}
+
+	var raw struct {
+		ID          int     `json:"id"`
+		Title       string  `json:"title"`
+		PosterPath  *string `json:"poster_path"`
+		ReleaseDate string  `json:"release_date"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return gallery.MovieResult{}, fmt.Errorf("failed to decode TMDb response: %v", err)
+	}
+
+	return gallery.MovieResult{
+		ID:          raw.ID,
+		Title:       raw.Title,
+		PosterPath:  raw.PosterPath,
+		ReleaseDate: raw.ReleaseDate,
+	}, nil
 }
 
 // DownloadImage downloads an image from imageURL and saves it to destPath.

--- a/internal/infrastructure/tmdb/client_test.go
+++ b/internal/infrastructure/tmdb/client_test.go
@@ -1,14 +1,14 @@
-package application
+package tmdb
 
 import "testing"
 
-func TestValidatePosterURL(t *testing.T) {
+func TestValidateImageURL(t *testing.T) {
 	allowed := []string{
 		"https://image.tmdb.org/t/p/w500/abc.jpg",
 		"https://IMAGE.TMDB.ORG/t/p/w185/def.jpg",
 	}
 	for _, u := range allowed {
-		if err := validatePosterURL(u); err != nil {
+		if err := validateImageURL(u); err != nil {
 			t.Errorf("expected %q to be allowed, got error: %v", u, err)
 		}
 	}
@@ -23,7 +23,7 @@ func TestValidatePosterURL(t *testing.T) {
 		"",                                            // empty
 	}
 	for _, u := range blocked {
-		if err := validatePosterURL(u); err == nil {
+		if err := validateImageURL(u); err == nil {
 			t.Errorf("expected %q to be blocked, but it was allowed", u)
 		}
 	}

--- a/pkg/handlers/admin_handlers.go
+++ b/pkg/handlers/admin_handlers.go
@@ -260,18 +260,26 @@ func (h *AdminHandlers) BulkClearThumbnailsHandler(w http.ResponseWriter, r *htt
 
 // FetchMoviePosterHandler handles API requests to fetch a movie poster with SSE progress
 func (h *AdminHandlers) FetchMoviePosterHandler(w http.ResponseWriter, r *http.Request) {
-	var videoPath, movieTitle, posterURL string
+	var videoPath, movieTitle string
+	var movieID int
 
 	// Support both POST (JSON body) and GET (query params for EventSource)
 	if r.Method == http.MethodGet {
 		videoPath = r.URL.Query().Get("videoPath")
 		movieTitle = r.URL.Query().Get("movieTitle")
-		posterURL = r.URL.Query().Get("posterUrl")
+		if movieIDStr := r.URL.Query().Get("movieId"); movieIDStr != "" {
+			parsed, err := strconv.Atoi(movieIDStr)
+			if err != nil || parsed < 0 {
+				http.Error(w, "movieId must be a non-negative integer", http.StatusBadRequest)
+				return
+			}
+			movieID = parsed
+		}
 	} else if r.Method == http.MethodPost {
 		var req struct {
 			VideoPath  string `json:"videoPath"`
 			MovieTitle string `json:"movieTitle"`
-			PosterURL  string `json:"posterUrl"`
+			MovieID    int    `json:"movieId"`
 		}
 		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -280,7 +288,7 @@ func (h *AdminHandlers) FetchMoviePosterHandler(w http.ResponseWriter, r *http.R
 		}
 		videoPath = req.VideoPath
 		movieTitle = req.MovieTitle
-		posterURL = req.PosterURL
+		movieID = req.MovieID
 	} else {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -310,7 +318,7 @@ func (h *AdminHandlers) FetchMoviePosterHandler(w http.ResponseWriter, r *http.R
 
 	progressCb := makeSSEProgressCallback(w, flusher)
 
-	if err := h.posterService.FetchMoviePoster(videoPath, movieTitle, posterURL, progressCb); err != nil {
+	if err := h.posterService.FetchMoviePoster(videoPath, movieTitle, movieID, progressCb); err != nil {
 		log.Printf("Error fetching movie poster: %v", err)
 		sendSSEError(w, flusher, err.Error())
 	}

--- a/pkg/handlers/admin_handlers.go
+++ b/pkg/handlers/admin_handlers.go
@@ -2,9 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/eknkc/pug"
@@ -12,6 +13,34 @@ import (
 	"video-gallery/internal/application"
 	"video-gallery/internal/domain/gallery"
 )
+
+// maxRequestBodyBytes caps JSON request bodies on the admin API endpoints.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+var (
+	videoExtensions = []string{".mp4", ".m4v", ".webm", ".mov", ".avi"}
+	imageExtensions = []string{".jpg", ".jpeg", ".png"}
+)
+
+// isValidObjectPath checks that a caller-supplied storage path has the expected
+// "category/gallery/file" shape and one of the allowed extensions. This keeps
+// the admin API from being used to read or delete arbitrary bucket objects.
+func isValidObjectPath(path string, allowedExts []string) bool {
+	if path == "" || strings.Contains(path, "..") || strings.Contains(path, "?") {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(parts[2]))
+	for _, allowed := range allowedExts {
+		if ext == allowed {
+			return true
+		}
+	}
+	return false
+}
 
 // Admin is the view model for the admin page
 type Admin struct {
@@ -58,7 +87,7 @@ func (h *AdminHandlers) AdminHandler(w http.ResponseWriter, r *http.Request) {
 
 	template, err := pug.CompileFile("./assets/templates/admin.pug", pug.Options{})
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Template error: %v", err), http.StatusInternalServerError)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		log.Printf("Template error: %v", err)
 		return
 	}
@@ -67,7 +96,7 @@ func (h *AdminHandlers) AdminHandler(w http.ResponseWriter, r *http.Request) {
 		Categories: h.galleryService.GetCategories(),
 		SecretKey:  secretKey,
 	}); err != nil {
-		http.Error(w, "Template execution error", http.StatusInternalServerError)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		log.Printf("Template execution error: %v", err)
 		return
 	}
@@ -83,13 +112,16 @@ func (h *AdminHandlers) GenerateThumbnailHandler(w http.ResponseWriter, r *http.
 		videoPath = r.URL.Query().Get("videoPath")
 		timeMs = 1000
 		if timeMsStr := r.URL.Query().Get("timeMs"); timeMsStr != "" {
-			fmt.Sscanf(timeMsStr, "%d", &timeMs)
+			if parsed, err := strconv.Atoi(timeMsStr); err == nil {
+				timeMs = parsed
+			}
 		}
 	} else if r.Method == http.MethodPost {
 		var req struct {
 			VideoPath string `json:"videoPath"`
 			TimeMs    int    `json:"timeMs"`
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
@@ -101,8 +133,12 @@ func (h *AdminHandlers) GenerateThumbnailHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if videoPath == "" {
-		http.Error(w, "videoPath is required", http.StatusBadRequest)
+	if !isValidObjectPath(videoPath, videoExtensions) {
+		http.Error(w, "videoPath must be a valid video object path", http.StatusBadRequest)
+		return
+	}
+	if timeMs < 0 {
+		http.Error(w, "timeMs must not be negative", http.StatusBadRequest)
 		return
 	}
 
@@ -137,8 +173,14 @@ func (h *AdminHandlers) ClearThumbnailHandler(w http.ResponseWriter, r *http.Req
 	var req struct {
 		ThumbnailPath string `json:"thumbnailPath"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if !isValidObjectPath(req.ThumbnailPath, imageExtensions) {
+		http.Error(w, "thumbnailPath must be a valid image object path", http.StatusBadRequest)
 		return
 	}
 
@@ -165,8 +207,14 @@ func (h *AdminHandlers) BulkGenerateThumbnailsHandler(w http.ResponseWriter, r *
 		TimeMs int  `json:"timeMs"`
 		Force  bool `json:"force"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.TimeMs < 0 {
+		http.Error(w, "timeMs must not be negative", http.StatusBadRequest)
 		return
 	}
 
@@ -225,6 +273,7 @@ func (h *AdminHandlers) FetchMoviePosterHandler(w http.ResponseWriter, r *http.R
 			MovieTitle string `json:"movieTitle"`
 			PosterURL  string `json:"posterUrl"`
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
@@ -237,8 +286,12 @@ func (h *AdminHandlers) FetchMoviePosterHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if videoPath == "" || movieTitle == "" {
-		http.Error(w, "videoPath and movieTitle are required", http.StatusBadRequest)
+	if movieTitle == "" {
+		http.Error(w, "movieTitle is required", http.StatusBadRequest)
+		return
+	}
+	if !isValidObjectPath(videoPath, videoExtensions) {
+		http.Error(w, "videoPath must be a valid video object path", http.StatusBadRequest)
 		return
 	}
 

--- a/terraform/gcp-video-gallery-module/main.tf
+++ b/terraform/gcp-video-gallery-module/main.tf
@@ -1,6 +1,8 @@
 // Random String
+// The secret key is the sole access control for the gallery and admin pages,
+// so it needs enough entropy to resist URL brute-forcing.
 resource "random_string" "gallery_key" {
-  length  = 4
+  length  = 32
   special = false
 }
 


### PR DESCRIPTION
## Summary

This PR hardens the application against several security vulnerabilities by eliminating DOM-based XSS risks, adding strict input validation to admin API endpoints, implementing security headers, removing a user-controlled URL from the poster download path (CodeQL SSRF finding), and strengthening the generated secret key.

## Key Changes

**Frontend Security (admin.pug)**
- Replaced all `innerHTML` assignments with safe DOM APIs (`textContent`, `createElement`, `appendChild`) to prevent XSS injection from external sources (API errors, TMDb movie data)
- Added `setStatusProgress()` helper function to safely render progress bars without markup injection
- Refactored poster selection UI from HTML string concatenation to DOM element construction, eliminating XSS vectors from movie titles and URLs sourced from the external TMDb API

**SSRF Fix — Poster Downloads by TMDb Movie ID (poster_service.go, tmdb/client.go)**
- CodeQL flagged the poster download as "Uncontrolled data used in network request": the admin UI passed a full poster URL that flowed into an outbound HTTP request
- The admin UI now sends the TMDb movie ID (an integer); the server looks up the poster path via TMDb's `/3/movie/{id}` API, so download URLs are always constructed server-side from constants plus TMDb's own responses
- The HTTPS + host allowlist check in `DownloadImage` remains as defense in depth (test moved to the tmdb package)

**Backend Input Validation (admin_handlers.go)**
- Added `isValidObjectPath()` to validate caller-supplied storage paths, ensuring they follow the "category/gallery/file" structure and have allowed extensions
- Applied path validation to all admin API endpoints: `GenerateThumbnailHandler`, `ClearThumbnailHandler`, `BulkGenerateThumbnailsHandler`, and `FetchMoviePosterHandler`
- Added request body size limits (1 MiB) using `http.MaxBytesReader` on all JSON endpoints
- Replaced `fmt.Sscanf` with `strconv.Atoi` for parsing timeMs, and rejected negative values
- Improved error messages to avoid leaking implementation details

**Security Headers (serve_cmd.go)**
- Implemented `securityHeaders()` middleware adding standard browser security headers:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: no-referrer` (prevents secret key leakage via Referer header)
  - Comprehensive `Content-Security-Policy` with restricted directives
- Configured HTTP server with appropriate timeouts (ReadHeaderTimeout, ReadTimeout, IdleTimeout) while avoiding WriteTimeout for SSE endpoints
- Switched from `http.ListenAndServe` to explicit `http.Server` configuration

**Secret Key Hardening (terraform)**
- Increased the Terraform-generated `SECRET_KEY` length from 4 to 32 characters to provide sufficient entropy for URL brute-force resistance
- Gallery URL stubs deliberately remain 4 characters so gallery links stay short and shareable; the trade-off (discoverable by enumerating `/gallery/`) is documented in the code and SECURITY.md

**Documentation (SECURITY.md)**
- Replaced template boilerplate with vulnerability reporting instructions via GitHub Security Advisories
- Added deployment security notes covering secret key management, HTTPS requirement, capability-link semantics of gallery URLs, and GCS bucket configuration

## Notable Implementation Details

- The `isValidObjectPath()` validation prevents directory traversal (`..`), query-string injection (`?`), and enforces a strict 3-part path structure
- DOM construction in the poster selection UI preserves all external data safely while maintaining the original HTML structure and styling
- The CSP policy allows `'unsafe-inline'` for scripts and styles only because the pug templates use inline code; this is acceptable given the secret key access control

https://claude.ai/code/session_016oCPorC6DfMkiqMchxCSMe