### PR TITLE
Replace Taskfile with Makefile to remove go-task dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build frontend-build clean
+
+build:
+	go build ./...
+
+frontend-build:
+	npm install
+	npm run build
+
+clean:
+	rm -rf public/styles.css node_modules

--- a/scripts/Taskfile.yml
+++ b/scripts/Taskfile.yml
@@ -1,6 +1,0 @@
-version: '3'
-
-includes:
-  shared:
-    taskfile: ~/.tasks/Taskfile.yml
-    optional: true


### PR DESCRIPTION
## Summary
- Add root `Makefile` with `build`, `frontend-build`, and `clean` targets
- Delete `scripts/Taskfile.yml` which contained only an optional shared include and no project tasks

## Test plan
- [ ] `make build` compiles the Go binary
- [ ] `make frontend-build` installs npm deps and compiles SCSS to CSS
- [ ] `make clean` removes build artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsAuVZBw9cgsrGcvhXpX6Q)_