### PR TITLE
Fix security vulnerabilities found in review

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Bump version and create tag
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         id: bump
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 yarn.lock
 
 # local env files
+.env
 .env.local
 .env.*.local
 

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -99,6 +99,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; img-src 'self' https: data:; media-src 'self' https:; "+
 				"script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "+

--- a/internal/application/gallery_service.go
+++ b/internal/application/gallery_service.go
@@ -82,12 +82,13 @@ func (s *GalleryService) GetGalleries() []gallery.Gallery {
 		if g, exists := galleryMap[galleryName]; exists {
 			g.Videos = append(g.Videos, video)
 		} else {
-			// Gallery URL stub. Kept intentionally short (4 chars) so gallery
-			// links stay easy to share, at the cost of being guessable by
-			// enumeration of the /gallery/ namespace.
+			// Gallery URL stub. Derived from the gallery name salted with the
+			// secret key. Uses 16 base64url chars (~96 bits) so the stub stays
+			// short enough to share while being infeasible to guess by
+			// enumeration of the unauthenticated /gallery/ namespace.
 			hash := sha256.New()
 			hash.Write([]byte(galleryName + s.secretKey))
-			hashStr := base64.URLEncoding.EncodeToString(hash.Sum(nil))[0:4]
+			hashStr := base64.URLEncoding.EncodeToString(hash.Sum(nil))[0:16]
 
 			galleryMap[galleryName] = &gallery.Gallery{
 				Name:     galleryName,

--- a/internal/infrastructure/gcs/repository.go
+++ b/internal/infrastructure/gcs/repository.go
@@ -138,7 +138,7 @@ func validateLocalPath(path string) error {
 		return fmt.Errorf("path must be absolute: %s", path)
 	}
 	expectedDir := filepath.Clean(filepath.Join(os.TempDir(), "video-gallery-thumbnails"))
-	if !strings.HasPrefix(cleanPath, expectedDir) {
+	if cleanPath != expectedDir && !strings.HasPrefix(cleanPath, expectedDir+string(os.PathSeparator)) {
 		return fmt.Errorf("invalid path: must be within temp directory")
 	}
 	return nil

--- a/internal/infrastructure/tmdb/client.go
+++ b/internal/infrastructure/tmdb/client.go
@@ -3,6 +3,7 @@ package tmdb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +66,7 @@ func (c *Client) SearchMovies(_ context.Context, title string) ([]gallery.MovieR
 	searchURL := fmt.Sprintf("%s?api_key=%s&query=%s", tmdbSearchURL, apiKey, url.QueryEscape(title))
 	resp, err := httpClient.Get(searchURL) // #nosec G107 -- URL is constructed from a trusted constant + encoded user input
 	if err != nil {
-		return nil, fmt.Errorf("failed to search TMDb: %v", err)
+		return nil, fmt.Errorf("failed to search TMDb: %v", scrubURLError(err))
 	}
 	defer resp.Body.Close()
 
@@ -103,7 +104,7 @@ func (c *Client) GetMovie(_ context.Context, id int) (gallery.MovieResult, error
 	movieURL := fmt.Sprintf("%s/%d?api_key=%s", tmdbMovieURL, id, apiKey)
 	resp, err := httpClient.Get(movieURL) // #nosec G107 -- URL is a trusted constant plus an integer ID
 	if err != nil {
-		return gallery.MovieResult{}, fmt.Errorf("failed to fetch movie from TMDb: %v", err)
+		return gallery.MovieResult{}, fmt.Errorf("failed to fetch movie from TMDb: %v", scrubURLError(err))
 	}
 	defer resp.Body.Close()
 
@@ -185,4 +186,14 @@ func (c *Client) resolveAPIKey() string {
 		return c.apiKey
 	}
 	return os.Getenv("TMDB_API_KEY")
+}
+
+// scrubURLError strips the request URL from an *url.Error so that the api_key
+// query parameter is never included in a returned or logged error message.
+func scrubURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return urlErr.Err
+	}
+	return err
 }

--- a/terraform/gcp-video-gallery-module/main.tf
+++ b/terraform/gcp-video-gallery-module/main.tf
@@ -1,7 +1,8 @@
-// Random String
+// Random secret
 // The secret key is the sole access control for the gallery and admin pages,
-// so it needs enough entropy to resist URL brute-forcing.
-resource "random_string" "gallery_key" {
+// so it needs enough entropy to resist URL brute-forcing. random_password marks
+// the generated value as sensitive so it is not shown in `terraform plan` output.
+resource "random_password" "gallery_key" {
   length  = 32
   special = false
 }
@@ -35,7 +36,7 @@ resource "google_cloud_run_service" "video_gallery" {
 
         env {
           name  = "SECRET_KEY"
-          value = random_string.gallery_key.result
+          value = random_password.gallery_key.result
         }
 
         resources {


### PR DESCRIPTION
- gallery: widen public /gallery/ stub from 4 to 16 base64url chars
  (~24 -> ~96 bits) so shareable links can no longer be brute-forced to
  enumerate galleries and their signed video URLs.
- tmdb: strip the request URL from *url.Error before returning/logging so
  the api_key query parameter can no longer leak into admin error output.
- serve: add Strict-Transport-Security (HSTS) response header.
- gcs: tighten validateLocalPath prefix check so sibling directories like
  "...-thumbnails-evil" are rejected (defense-in-depth).
- terraform: use random_password instead of random_string for the gallery
  secret so the value is marked sensitive and hidden from plan output.
- ci: pin anothrNick/github-tag-action to a commit SHA.
- gitignore: ignore plain .env files.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X9LUCpNfvCEimWCbtTM8yn