### PR TITLE
Run only the relevant tests for a PR's changed paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
     needs: [changes, backend, frontend]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check job results
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,41 @@ on:
       - 'master'
 
 jobs:
-  test:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect changed areas
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'assets/templates/**'
+              - 'Makefile'
+              - '.github/workflows/test.yml'
+            frontend:
+              - 'assets/scss/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.node-version'
+              - '.github/workflows/test.yml'
+
+  backend:
+    name: Backend
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment: default
     permissions:
@@ -25,6 +59,28 @@ jobs:
           go-version: 'stable'
           cache: true
 
+      - name: Build Backend
+        run: go build ./...
+
+      - name: Test Backend
+        run: go test ./...
+
+  frontend:
+    name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    environment: default
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -37,5 +93,18 @@ jobs:
       - name: Build Styles
         run: npm run build
 
-      - name: Build Backend
-        run: go build -o video-gallery
+  # Aggregates the conditional jobs above into a single required status check,
+  # since GitHub branch protection can't target jobs that are skipped based on
+  # the paths that changed.
+  test:
+    name: Test
+    needs: [changes, backend, frontend]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          if [[ "${{ needs.backend.result }}" == "failure" || "${{ needs.frontend.result }}" == "failure" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml` now uses `dorny/paths-filter` to detect whether a PR touches backend paths (`**/*.go`, `go.mod`/`go.sum`, `assets/templates/**`, `Makefile`) vs frontend paths (`assets/scss/**`, `package.json`/`package-lock.json`, `.node-version`), and only runs the matching job — a Go-only PR skips the npm/SCSS build, a styling-only PR skips the Go build/test.
- Added a `go test ./...` step to the backend job — the workflow previously only ran `go build`, so no Go tests actually executed in CI.
- Added a trailing `test` aggregator job (`needs: [changes, backend, frontend]`, `if: always()`) that fails if either conditional job failed, so there's still a single stable "Test" check to use for branch protection even though the underlying jobs are conditionally skipped.
- Both `backend` and `frontend` jobs (and the aggregator) also run whenever the workflow file itself changes, so edits to the pipeline are always fully exercised.

## Test plan
- [x] `go build ./...` and `go test ./...` pass locally
- [x] `npm ci && npm run build` (SCSS compile) passes locally
- [x] Validated the new workflow YAML parses correctly
- [ ] Confirm the `changes`/`backend`/`frontend`/`test` jobs behave as expected on this PR's own Actions run (backend-only diff, so `frontend` should skip)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx9EjQMkSZpytTLupzrH8s)_